### PR TITLE
Fixing the rss feed

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -9,7 +9,7 @@ search:           true
 
 # Owner/author information
 owner:
-  name:           "Danilo Sato & Rafael Rosa"
+  name:           "Danilo Sato and Rafael Rosa"
   avatar:         bio-photo.jpg
   email:          contact@mindthecloud.com
   # Social networking links used in footer. Update and remove as you like.


### PR DESCRIPTION
In order to fix the rss feed I found out that the character '&' between the author names was messing up with the parsing.
This is particularly annoying because my podcast client crashes doesn't matter I try to do to fetch the episodes. 
